### PR TITLE
fix node-grovepi dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Node-RED nodes to control GrovePi+ sensors.",
   "dependencies": {
-    "node-grovepi": "2.0.7"
+    "node-grovepi": "2.1.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Raspbian Jessie on RPI3
Using the scipt to upgrade nodejs, npm and node-red I now work with:
NodeJS:     v6.9.4
npm:        v3.10.10
node-red:   v0.16.2

When I try to install node-red-grovepi-nodes installations fails. Error compiling i2c.
This because these nodes depend on node-grovepi 2.0.7, that depends on an old i2c and i2c-bus version
