### PR TITLE
Final fix for npm v3

### DIFF
--- a/grovepi.js
+++ b/grovepi.js
@@ -15,8 +15,8 @@
  **/
 
 var GrovePi = require('node-grovepi').GrovePi;
-var i2c = require('./node_modules/node-grovepi/node_modules/i2c-bus/i2c-bus');
-var sleep = require('./node_modules/node-grovepi/node_modules/sleep/');
+var i2c = require('i2c-bus');
+var sleep = require('sleep/');
 
 var Commands = GrovePi.commands
 var Board = GrovePi.board

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Node-RED nodes to control GrovePi+ sensors.",
   "dependencies": {
     "node-grovepi": "2.1.1",
-    "i2c-bus": "1.x"
+    "i2c-bus": "1.x",
+    "sleep": "3.x"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "description": "Node-RED nodes to control GrovePi+ sensors.",
   "dependencies": {
-    "node-grovepi": "2.1.1"
+    "node-grovepi": "2.1.1",
+    "i2c-bus": "1.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
npm v3 use a different schema for submodule path, putting them at the same level (no more nested modules)  I removed relative nested path in grovepi.js  

I also added i2c-bus and sleep dependencies to package.json, because used in grovepi.js.

I tested npm installation from my github in both npm v2 and npm v3 version, on raspberryPI, and seems to work